### PR TITLE
fix lexical require for Terminal::ANSIColor

### DIFF
--- a/t/71_filter.t
+++ b/t/71_filter.t
@@ -44,7 +44,7 @@ multi sub elements_filter(Data::Dump::Tree $s, ($depth, $glyph, @renderings), @s
 my $d = Data::Dump::Tree.new(color => False) ;
 my $dump = $d.get_dump($d, header_filters => (&header_filter,), elements_filters => (&elements_filter,)) ;
 
-is $dump.lines.elems, 31, 'lines output' or diag $dump ;
+is $dump.lines.elems, 32, 'lines output' or diag $dump ;
 like $dump, /removing/, 'removing' or diag $dump ;
 like $dump, /'not removing'/, 'not removing' or diag $dump ;
 like $dump, /'SUB ELEMENTS'/, 'sub elements filter' or diag $dump ;


### PR DESCRIPTION
due to a new attribute in AnsiColor, one test has to expect
one additional line of output now.