### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -3,6 +3,7 @@
 "perl" : "6.c",
 
 "name" : "Data::Dump::Tree",
+"license" : "Artistic-2.0",
 "version" : "1.0.3",
 "authors" : ["Nadim Khemir"],
 


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license