### PR TITLE
Indicate dependency

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -32,7 +32,7 @@
 	"Data::Dump::Tree::MultiColumns" : "lib/Data/Dump/Tree/MultiColumns.pm"
 	},
 
-"depends" : [ ],
+"depends" : [ "Terminal::Print" ],
 "test-depends" : [ "Test", "Test::META"  ],
 
 "tags" :


### PR DESCRIPTION
By indicating a dependency on Terminal::Print in the META6.json file, that module will automatically be installed when installing Data::Dump::Tree (instead of DDT failing to install because Terminal::Print is missing).