### PR TITLE
Fixed a num64 deprecation issue.

### DIFF
--- a/t/48_type_NativeCall.t
+++ b/t/48_type_NativeCall.t
@@ -37,12 +37,12 @@ is $dump.lines.elems, 3, '3 lines' or diag $dump ;
 like $dump, /'<CUnion>'/, '<CUnion>' or diag $dump ;
 
 class MyStruct is repr('CStruct') {
-	has Point $.point;  # referenced 
-	submethod TWEAK() { $!point := Point.new }; 
+	has Point $.point;  # referenced
+	submethod TWEAK() { $!point := Point.new };
 }
 
 my $mystruct = MyStruct.new ;
-$mystruct.point.x = num64.new(888e0)  ;
+$mystruct.point.x = (my num64 $ = 888e0)  ;
 
 $dump = $d.ddt: :get, $mystruct ;
 is $dump.lines.elems, 5, '5 lines' or diag $dump ;
@@ -65,7 +65,7 @@ $dump = $d.ddt: :get, $pointer;
 is $dump.lines.elems, 1, '1 line' or diag $dump ;
 like $dump, /'<CPointer>'/, '<CPointer>' or diag $dump ;
 
-my int32 @int32 = 6, 7, 8 ; 
+my int32 @int32 = 6, 7, 8 ;
 $dump = $d.ddt: :get, @int32;
 is $dump.lines.elems, 4, '4 lines' or diag $dump ;
 like $dump, /'<array>'/, '<array>' or diag $dump ;


### PR DESCRIPTION
Error was this so I did what it said:

	t/48_type_NativeCall.t ....... 1/17 Saw 1 occurrence of deprecated code.
	================================================================================
	Block <unit> (from unknown) seen at:
	  t/48_type_NativeCall.t, line 45
	Deprecated since v2017.09.403, will be removed with release v2018.01!
	Please use (my num64 $ = 888e0) instead.
	--------------------------------------------------------------------------------