### PR TITLE
Remove all calls of deleted function `get_element_glyphs`

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -4,7 +4,7 @@
 
 "name" : "Data::Dump::Tree",
 "license" : "Artistic-2.0",
-"version" : "2.8.0",
+"version" : "2.8.1",
 "auth"    : "github:nkh",
 "authors" : ["Nadim Khemir"],
 

--- a/lib/Data/Dump/Tree/Diff.pm6
+++ b/lib/Data/Dump/Tree/Diff.pm6
@@ -215,9 +215,12 @@ else
 
 			for zipi(@sub_elements1, @sub_elements2) -> ($index, $sub1, $sub2)
 				{
-				my $sub_element_glyphs1 = $d1.get_element_glyphs(%glyphs1,  $index == @sub_elements1.end) ;
-				my $sub_element_glyphs2 = $d2.get_element_glyphs(%glyphs2,  $index == @sub_elements2.end) ;
-
+				my $sub_element_glyphs1 = $index == @sub_elements1.end
+								?? %glyphs1<__width last     last_continuation     multi_line empty filter>
+								!! %glyphs1<__width not_last not_last_continuation multi_line empty filter> ;
+				my $sub_element_glyphs2 = $index == @sub_elements2.end
+								?? %glyphs2<__width last     last_continuation     multi_line empty filter>
+								!! %glyphs2<__width not_last not_last_continuation multi_line empty filter> ;
 				if $sub1.defined && $sub2.defined
 					{
 					$is_different +=  $.diff_elements(


### PR DESCRIPTION
This function was removed in an earlier commit, but all references to
it were not removed. This causes a bug in 2.8.0 when
Data::Dump::Tree::Diff is used.