### PR TITLE
Fix dumping of things that have Pair in them

### DIFF
--- a/lib/Data/Dump/Tree.pm6
+++ b/lib/Data/Dump/Tree.pm6
@@ -601,7 +601,7 @@ method !get_element_subs(Mu $s)
 my regex ansi_color { \e \[ \d+ [\;\d+]* <?before [\;\d+]* > m }
 
 method !split_entry(
-	Int $current_depth, $width, Cool $k, Cool $b,
+	Int $current_depth, $width, Any $k, Cool $b,
 	Int $glyph_width, Cool $v, $f is copy,
 	($ddt_address is copy, $link, $perl_address))
 {
@@ -609,6 +609,8 @@ my (@kvf, @ks, @vs, @fs) ;
 
 # handle \t
 my ($k2, $v2, $f2) = ($k // '', $v // '', $f // '')  ;
+# handle Pair is keys, one of the few things that are not Cool.
+$k2 = ~$k2 unless $k2 ~~ Cool;
 if $.tab_size { ($k2, $v2, $f2) = ($k2, $v2, $f2).map: { .subst(/\t/, ' ' x $.tab_size, :g) } }
 
 my $v2_width = (S:g/ <ansi_color> // given $v2).chars ;

--- a/lib/Data/Dump/Tree/DescribeBaseObjects.pm6
+++ b/lib/Data/Dump/Tree/DescribeBaseObjects.pm6
@@ -76,11 +76,11 @@ multi method get_header (Grammar:U $g) { '', '.' ~ $g.^name, DDT_FINAL }
 
 multi method get_header (Bag:U $b) { '', '.' ~ $b.^name, DDT_FINAL }
 multi method get_header (Bag:D $b) { '', '.' ~ $b.^name ~ '(' ~ $b.elems ~ ')' }
-multi method get_elements (Bag $b) { |($b.sort(*.key)>>.kv.map: -> ($k, $v) {$k, ' => ', $v}) }
+multi method get_elements (Bag $b) { |($b.sort(*.key).map: {.key, ' => ', .value}) }
 
 multi method get_header (BagHash:U $b) { '', '.' ~ $b.^name, DDT_FINAL }
 multi method get_header (BagHash:D $b) { '', '.' ~ $b.^name ~ '(' ~ $b.elems ~ ')' }
-multi method get_elements (BagHash $b) { |($b.sort(*.key)>>.kv.map: -> ($k, $v) {$k, ' => ', $v}) }
+multi method get_elements (BagHash $b) { |($b.sort(*.key).map: {.key, ' => ', .value}) }
 
 multi method get_header (Set:D $s) { '', '.' ~ $s.^name ~ '(' ~ $s.elems ~ ')'  }
 multi method get_elements (Set $s) {
@@ -214,18 +214,16 @@ multi method get_header (Hash:U $h) { '', '{}', DDT_FINAL }
 multi method get_header (Hash:D $h) { '', '{' ~ $h.elems ~ '}' ~ $h.^name.substr(4) }
 multi method get_elements (Hash:D $h) {
 	|self!get_attributes($h, <descriptor storage>),
-	|($h.sort(*.key)>>.kv.map: -> ($k, $v) {$k, ' => ', $v}) }
+	|($h.sort(*.key).map: {.key, ' => ', .value}) }
 
 multi method get_header (Stash $s) { '', '.' ~ $s.^name ~ ' {' ~ ($s.keys.flat.elems) ~ '}' }
 
-# error in Rakudo
-#multi method get_elements (Stash $s) { $s.sort(*.key)>>.kv.map: -> ($k, $v) {$k, ' => ', $v} }
-multi method get_elements (Stash $s) { $s.sort(*.key)>>.&{.key, .value}.map: -> ($k, $v) {$k, ' => ', $v} }
+multi method get_elements (Stash $s) { $s.sort(*.key).map: {.key, ' => ', .value} }
 
 multi method get_header (Map $m) { '', '.' ~ $m.^name }
 multi method get_elements (Map $m) {
 	|self!get_attributes($m, (<storage>,)),
-	|$m.sort(*.key)>>.kv.map: -> ($k, $v) {$k, ' => ', $v} }
+	|$m.sort(*.key).map: {.key, ' => ', .value} }
 
 multi method get_header (Enumeration $e) { '', '.' ~ $e.^name, DDT_FINAL }
 

--- a/t/40_type_Map.t
+++ b/t/40_type_Map.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl6
 
 use Test ;
-plan 1 ;
+plan 4 ;
 
 use Data::Dump::Tree ;
 
@@ -10,3 +10,13 @@ my $d = Data::Dump::Tree.new ;
 my $dump = $d.ddt: :get, Map.new('a', 1, 'b', 2), :!color, :width(75) ;
 
 is $dump.lines.elems, 3, '3 lines of dump for Map' or diag $dump ;
+
+$dump = $d.ddt: :get, Map.new('a', (a => True), 'b', (b => False)), :!color, :width(75) ;
+
+is $dump.lines.elems, 3, '3 lines of dump for Map with pair keys' or diag $dump ;
+
+$dump = $d.ddt: :get, Map.new((key => True), (value => True), (key => (innerkey => True)), (value => (innervalue => True))), :!color, :width(75) ;
+is $dump.lines.elems, 3, '3 lines of dump for Map with pair keys' or diag $dump ;
+
+$dump = $d.ddt: :get, Map.new((key => (innerkey => True)), (value => (innervalue => True)), (key => (innerkey => (innerinnerkey => True))), (value => (innervalue => (innerinnervalue => True)))), :!color, :width(75) ;
+is $dump.lines.elems, 7, '7 lines of dump for Map with pairs with pairs as value' or diag $dump ;

--- a/t/44.pair.t
+++ b/t/44.pair.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl6
 
 use Test ;
-plan 4 ;
+plan 17 ;
 
 use Data::Dump::Tree ;
 
@@ -17,3 +17,40 @@ $dump = $d.ddt: :get, (a => (< a >,)), :!color ;
 like $dump.lines[0], /^'.Pair'/, 'class name' or diag $dump ;
 is($dump.lines.elems, 4, '4 dump lines') or diag $dump ;
 
+
+for (Array, List) -> \typ {
+    subtest typ.gist, {
+        $dump = $d.ddt: :get, typ.new((a => (a => 1))), :!color ;
+        like $dump.lines[1], /' .Pair'/, 'class name' or diag $dump ;
+        is($dump.lines.elems, 4, '4 dump lines') or diag $dump ;
+    }
+}
+
+$dump = $d.ddt: :get, Array.new((a => (a => 1))).Seq, :!color ;
+like $dump.lines[1], /'.Pair'/, 'class name' or diag $dump ;
+is($dump.lines.elems, 4, '4 dump lines') or diag $dump ;
+
+for (Hash, Map, Stash) -> \typ {
+    subtest typ.gist, {
+        $dump = $d.ddt: :get, typ.new("a", (a => 1)), :!color ;
+        like $dump.lines[1], /'.Pair'/, 'class name' or diag $dump ;
+        is($dump.lines.elems, 2, '2 dump lines') or diag $dump ;
+    }
+    subtest typ.gist ~ ".Seq", {
+        $dump = $d.ddt: :get, typ.new("a", (a => 1)).Seq, :!color ;
+        like $dump.lines[1], /' .Pair'/, 'class name' or diag $dump ;
+        is($dump.lines.elems, 4, '4 dump lines') or diag $dump ;
+    }
+}
+
+$dump = $d.ddt: :get, [a => (a => 1)], :!color ;
+like $dump.lines[1], /' .Pair'/, 'class name' or diag $dump ;
+is($dump.lines.elems, 4, '4 dump lines') or diag $dump ;
+
+my Any %silly_stuff{Any};
+
+%silly_stuff{((innerkey => True) => "key's_value")} = (innervalue => True) => "values_value";
+%silly_stuff{((innerkey => (innerinnerkey => True)) => "deep_keys_value")} = (innervalue => (innerinnervalue => True)) => "deep_values_value";
+
+$dump = $d.ddt: :get, %silly_stuff, :!color, :width(75) ;
+is $dump.lines.elems, 10, '10 lines of dump for Object Hash with nested pairs as keys and pairs as values' or diag $dump ;


### PR DESCRIPTION
Instead of using .kv on a list of pairs and unpacking the sub-lists
into a key and value variable using a sub-signature,
take the pairs directly and access their .key and .value getters.
This circumvents the issue that a Pair present in a list will
be passed as a named argument to a subsignature.

This gave the error "Too few positionals passed to '<anon>'; expected 2 arguments but got 1 in sub-signature"
in various methods in Data::Dump::Tree::DescribeBaseObjects